### PR TITLE
Remove extension key and update build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ Replace new tab page with a customized dashboard to help you get focused, and ke
 " target="_blank"><img alt="Chrome Web Store" src="https://img.shields.io/chrome-web-store/v/jhpdbbakbcmoaondmjjjbojlakgkeilo"></a>
 <br>
 <br>
+## Build
+
+Install dependencies with `npm install` and provide your extension private key via the `EXTENSION_KEY` environment variable when running the build script:
+
+```bash
+EXTENSION_KEY="<your-key>" npm run build
+```
+
+The bundled extension will be generated in the `dist` directory.
+
 
 ## Tech
 

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -3,8 +3,7 @@
   "name": "Catalyst",
   "description": "Browser Productivity Tools",
   "version": "1.0.9",
-  "key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmKf5/H6EYwQoN/ShiB+KwH4KUd8XUwgiNsxQmiPE/1tXP20ahZl1SX7YQYdZU7tc8uw5GBiRV6NXEFU7ywtXLMvQD7EIBNZ68YKHPlCRNI7PXnqIuopD1JRwvsF/hq+O0UMU23dPN3kshZo04vo+cJ8J0Sg27kZpNdRH8x4VEuHOPQPZ7+DiNeKHpuIfT0kPbve1pTewnGiy+M45OLODn1Gr7HpkwiOu4u/mAtoi0ns6jUNIvRvh4A8ErCfheBCNeqefb/0SLi0ytygRExSmX6kPhr5ri3wADysZimhVaPBoSlffwFoZYc1qG3lT4wsUIOGIJwHETsx9jMSfdQhCSwIDAQAB",
-  "icons":{
+  "icons": {
     "16": "CatalystLogo_128.png",
     "48": "CatalystLogo_128.png",
     "128": "CatalystLogo_128.png"
@@ -15,7 +14,7 @@
     "default_icon": "CatalystLogo_128.png"
   },
   "options_page": "options.html",
-  "chrome_url_overrides" : {
+  "chrome_url_overrides": {
     "newtab": "newtab.html"
   },
   "background": {
@@ -27,11 +26,24 @@
       "https://www.googleapis.com/auth/calendar"
     ]
   },
-  "permissions":["storage", "alarms", "notifications", "identity", "identity.email", "contextMenus", "search", "tts"],
+  "permissions": [
+    "storage",
+    "alarms",
+    "notifications",
+    "identity",
+    "identity.email",
+    "contextMenus",
+    "search",
+    "tts"
+  ],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
-      "js": ["contentScript.js"]
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "contentScript.js"
+      ]
     }
   ]
 }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -37,6 +37,17 @@ module.exports = {
         {
           from: path.resolve('src/static'),
           to: path.resolve('dist'),
+          transform(content, absolutePath) {
+            if (
+              absolutePath.endsWith('manifest.json') &&
+              process.env.EXTENSION_KEY
+            ) {
+              const manifest = JSON.parse(content.toString())
+              manifest.key = process.env.EXTENSION_KEY
+              return Buffer.from(JSON.stringify(manifest, null, 2))
+            }
+            return content
+          },
         },
       ],
     }),


### PR DESCRIPTION
## Summary
- remove hard-coded key from manifest.json
- inject key during build using EXTENSION_KEY env variable
- document how to supply the key when building

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f310e72148324a6fb6d1529ea6ffb